### PR TITLE
Add initialData argument to bootstrapGrist with URL of file to import

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Browsers don't have native support for Grist [yet :-)] but you can make a little
 
   * I've been pushing Grist code to https://grist-static.com/ as a CDN; you can produce it all yourself using this repo.
   * After that, it is just a case of putting a `.grist` file on your server beside this `.html` file, and filing in the options to `bootstrapGrist`.
+  * You can also pass `initialData: 'path/to/data.csv'` to import a CSV file into a new table. In this case `initialFile` is optional.
 
 ## Differences with regular Grist
 

--- a/ext/app/pipe/bootstrap.js
+++ b/ext/app/pipe/bootstrap.js
@@ -15,6 +15,9 @@ function bootstrapGrist(options) {
   if (seedFile) {
     window.seedFile = new URL(seedFile, window.location.href);
   }
+  if (options.initialData) {
+    window.initialData = options.initialData;
+  }
   const fakeDocId = "new~2d6rcxHotohxAuTxttFRzU";
   const fakeUrl = "https://example.com/o/docs/doc/new~2d6rcxHotohxAuTxttFRzU";
   window.fakeUrl = fakeUrl;

--- a/ext/app/pipe/webworker.js
+++ b/ext/app/pipe/webworker.js
@@ -65,6 +65,13 @@ os.environ['IMPORTDIR'] = '/import'
 sandbox = sandbox_mod.default_sandbox = sandbox_mod.Sandbox(None, None)
 sandbox.run = lambda: print("Sandbox is running")
 
+def save_file(path, content):
+  with open(path, 'w') as f:
+    f.write(content)
+
+sandbox.register('save_file', save_file)
+
+
 def call_external(name, *args):
   result = js.callExternal(name, args)
   return result.to_py()

--- a/ext/app/server/lib/CommStub.ts
+++ b/ext/app/server/lib/CommStub.ts
@@ -165,7 +165,7 @@ export class Comm  extends dispose.Disposable implements GristServerAPI, DocList
         uploadFileIndex: 0,
         transformRuleMap: {},
       };
-      await this.ad._activeDocImport._importParsedFileAsNewTable(
+      await this.ad.importParsedFileAsNewTable(
         this.session, parsedFile, importOptions
       )
     }

--- a/ext/app/server/lib/CommStub.ts
+++ b/ext/app/server/lib/CommStub.ts
@@ -76,9 +76,10 @@ export class Comm  extends dispose.Disposable implements GristServerAPI, DocList
     (window as any).gristActiveDoc = this.ad;
     //await this.ad.createEmptyDoc({});
     const hasSeed = (window as any).seedFile;
+    const initialDataUrl = (window as any).initialData;
     await this.ad.loadDoc({mode: 'system'}, {
       forceNew: !hasSeed,
-      skipInitialTable: hasSeed,
+      skipInitialTable: hasSeed || initialDataUrl,
       useExisting: true,
     });
     this.client = {
@@ -144,7 +145,6 @@ export class Comm  extends dispose.Disposable implements GristServerAPI, DocList
     }, {});
     (window as any).ad = this.ad;
 
-    const initialDataUrl = (window as any).initialData;
     if (initialDataUrl) {
       const content = await (await fetch(initialDataUrl)).text();
       // Extract filename from end of URL

--- a/page/StudentData.csv
+++ b/page/StudentData.csv
@@ -1,0 +1,6 @@
+Student,School,DOB
+Mike,1,2/13/92
+Joe,2,12/30/85
+Tom,1,1/4/96
+Sue,3,5/18/91
+Bill,3,6/12/94

--- a/page/index_initial_data.html
+++ b/page/index_initial_data.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf8">
+    <script src="static/pipe/bootstrap.js"></script>
+
+    <title>100% browser-based Grist</title>
+  </head>
+
+  <body>
+    <script>
+      bootstrapGrist({
+        name: 'Students',
+        initialData: './StudentData.csv',
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Uses https://github.com/gristlabs/grist-core/pull/564

Visit http://localhost:3030/page/index_initial_data.html to test.

This almost works, but as it applies the actions it runs into a version of https://github.com/gristlabs/grist-static/issues/5:

![Screenshot from 2023-07-10 15-20-11](https://github.com/gristlabs/grist-static/assets/3627481/c0597c10-3e7c-4aea-be2f-389cb38ba117)

It seems that the `['RemoveRecord', '_grist_Tables', 2]` action to remove the temporary `GristHidden_import` table is not properly processed before `['AddRecord', '_grist_Tables', 2, {tableId: 'StudentData', primaryViewId: 0}]`. 

I've poked around and not been able to understand what's going wrong. It smells like a race condition, maybe something about transactions. @paulfitz I need help with this.