### PR TITLE
make standard list of custom widgets available

### DIFF
--- a/ext/app/client/HookStub.ts
+++ b/ext/app/client/HookStub.ts
@@ -1,5 +1,6 @@
-import {defaultHooks, IHooks} from 'app/client/DefaultHooks';
+import { defaultHooks, IHooks } from 'app/client/DefaultHooks';
 import { IGristUrlState } from 'app/common/gristUrls';
+import { gristOverrides } from 'app/pipe/GristOverrides';
 
 export const hooks: IHooks = {
   ...defaultHooks,
@@ -7,7 +8,7 @@ export const hooks: IHooks = {
     credentialless: true,
   },
   fetch: fetcher,
-  baseURI: (window as any).bootstrapGristPrefix,
+  baseURI: gristOverrides.bootstrapGristPrefix,
   urlTweaks: {
     postEncode,
     preDecode,
@@ -25,8 +26,8 @@ function fetcher(...args: any[]) {
 function preDecode(options: {
   url: URL,
 }) {
-  console.log("FAKEURL?", (window as any).fakeUrl);
-  if (!(window as any).fakeUrl) {
+  const fakeUrl = gristOverrides.fakeUrl;
+  if (!fakeUrl) {
     return;
   }
   const at = new URL(options.url.href);
@@ -37,7 +38,7 @@ function preDecode(options: {
       extra = `/p/${p}`;
     }
   }
-  const location = new URL((window as any).fakeUrl + (extra || ''));
+  const location = new URL(fakeUrl + (extra || ''));
   location.search = at.search;
   location.hash = at.hash;
   options.url.href = location.href;
@@ -51,7 +52,8 @@ function postEncode(options: {
   baseLocation: Location | URL,
 }): void {
   const {url, parts} = options;
-  if (!(window as any).fakeUrl) {
+  const fakeUrl = gristOverrides.fakeUrl;
+  if (!fakeUrl) {
     return;
   }
   const at = new URL(location.href);

--- a/ext/app/client/tsconfig.json
+++ b/ext/app/client/tsconfig.json
@@ -7,5 +7,6 @@
   ],
   "references": [
     { "path": "../../../app/common" },
+    { "path": "../pipe" },
   ]
 }

--- a/ext/app/pipe/GristOverrides.ts
+++ b/ext/app/pipe/GristOverrides.ts
@@ -1,0 +1,23 @@
+/**
+ * grist-static passes around some global state in a hacky way.
+ * Here we at least try to shepherd the state into a single place.
+ */
+
+
+export interface GristOverrides {
+  bootstrapGristPrefix?: string;
+  staticGristOptions?: {
+    name?: string;
+  };
+  seedFile?: string;
+  initialData?: string;
+  fakeUrl?: string;
+  fakeDocId?: string;
+}
+
+export function getGristOverrides(): GristOverrides {
+  if (typeof window === 'undefined') { return {}; }
+  return (window as any).gristOverrides || {};
+}
+
+export const gristOverrides = getGristOverrides();

--- a/ext/app/pipe/bootstrap.js
+++ b/ext/app/pipe/bootstrap.js
@@ -1,7 +1,16 @@
+// Guess at where Grist assets live.
+const settings = window.gristOverrides = {};
 const bootstrapGristSource = document.currentScript?.src;
 const bootstrapGristPrefix = bootstrapGristSource ? new URL('..', bootstrapGristSource).href : '';
-window.bootstrapGristPrefix = bootstrapGristPrefix;
+// This next line should be left alone, there is a release script
+// that fiddles with it when prefix is none.
+settings.bootstrapGristPrefix = bootstrapGristPrefix;
 
+/**
+ * Kickstart Grist. See README for options.
+ * TODO: don't just take over entire page, restrict activities to
+ * within some element.
+ */
 function bootstrapGrist(options) {
   if (!globalThis.setImmediate) {
     // make do
@@ -11,17 +20,17 @@ function bootstrapGrist(options) {
   options = options || {};
   const seedFile = options.initialFile;
   const homeUrl = new URL('.', window.location.href).href;
-  window.staticGristOptions = options;
+  settings.staticGristOptions = options;
   if (seedFile) {
-    window.seedFile = new URL(seedFile, window.location.href);
+    settings.seedFile = new URL(seedFile, window.location.href);
   }
   if (options.initialData) {
-    window.initialData = options.initialData;
+    settings.initialData = options.initialData;
   }
   const fakeDocId = "new~2d6rcxHotohxAuTxttFRzU";
   const fakeUrl = "https://example.com/o/docs/doc/new~2d6rcxHotohxAuTxttFRzU";
-  window.fakeUrl = fakeUrl;
-  window.fakeDocId = fakeDocId;
+  settings.fakeUrl = fakeUrl;
+  settings.fakeDocId = fakeDocId;
   window.gristConfig = {
     "homeUrl":homeUrl,
     "org":"docs",
@@ -41,7 +50,7 @@ function bootstrapGrist(options) {
     "maxUploadSizeImport":null,
     "maxUploadSizeAttachment":null,
     "timestampMs":1678573297305,
-    "enableWidgetRepository":false,
+    "enableWidgetRepository":true,
     "survey":false,
     "tagManagerId":null,
     "activation":{"isManager":false},
@@ -69,7 +78,7 @@ function bootstrapGrist(options) {
     "bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js",
     "main.bundle.js"
   ];
-  const prefix = window.bootstrapGristPrefix || '';
+  const prefix = settings.bootstrapGristPrefix || '';
   for (const src of css) {
     const asset = document.createElement('link');
     asset.setAttribute('rel', 'stylesheet');

--- a/ext/app/pipe/tsconfig.json
+++ b/ext/app/pipe/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../buildtools/tsconfig-base-ext.json",
+  "include": [
+    "./GristOverrides.ts",
+  ],
+}

--- a/ext/app/server/Doc.ts
+++ b/ext/app/server/Doc.ts
@@ -14,10 +14,9 @@ import {create} from 'app/server/lib/create';
 
 process.env.GRIST_SANDBOX_FLAVOR = 'pyodideInline';
 
-// Provide a list of custom widgets. This URL is temporary,
-// until https://github.com/gristlabs/grist-widget/pull/52 lands.
+// Provide a default list of custom widgets.
 process.env.GRIST_WIDGET_LIST_URL =
-  'https://paulfitz.github.io/grist-widget/manifest.json';
+  'https://gristlabs.github.io/grist-widget/manifest.json';
 
 ActiveDocDeps.ACTIVEDOC_TIMEOUT_ACTION = 'ignore';
 

--- a/ext/app/server/Doc.ts
+++ b/ext/app/server/Doc.ts
@@ -13,6 +13,12 @@ import {NSandbox} from 'app/server/lib/NSandbox';
 import {create} from 'app/server/lib/create';
 
 process.env.GRIST_SANDBOX_FLAVOR = 'pyodideInline';
+
+// Provide a list of custom widgets. This URL is temporary,
+// until https://github.com/gristlabs/grist-widget/pull/52 lands.
+process.env.GRIST_WIDGET_LIST_URL =
+  'https://paulfitz.github.io/grist-widget/manifest.json';
+
 ActiveDocDeps.ACTIVEDOC_TIMEOUT_ACTION = 'ignore';
 
 class FakeDocStorageManager {

--- a/ext/app/server/lib/SQLite.ts
+++ b/ext/app/server/lib/SQLite.ts
@@ -1,3 +1,4 @@
+import { gristOverrides } from 'app/pipe/GristOverrides';
 import * as SqlJs from 'sql.js';
 import initSqlJs = require('sql.js');
 
@@ -22,18 +23,13 @@ export class Database {
   private db: Promise<SqlJs.Database>;
   constructor(path: string, mode: any, cb: (err: any, v?: any) => void) {
     this.db = new Promise<SqlJs.Database>((resolve, reject) => {
-      console.log("DB", path, mode);
       sql.then(async sql => {
         try {
-          console.log("working with.....", sql);
-          const seedFile = (window as any).seedFile;
-          console.log("Have a seed file?", {seedFile});
+          const seedFile = gristOverrides.seedFile;
           if (seedFile) {
-            console.log("Have a seed file", {seedFile});
             const resp = await window.fetch(seedFile);
             const data = await resp.arrayBuffer();
             const arr = new Uint8Array(data);
-            console.log("Got seed file data", {arr});
             resolve(new sql.Database(arr));
           } else {
             resolve(new sql.Database());
@@ -47,7 +43,6 @@ export class Database {
       });
     });
     this.db.then(d => {
-      console.log("GOT", d);
       cb(null, d);
     });
   }
@@ -77,21 +72,17 @@ export class Database {
       } finally {
         stmt.free();
       }
-      console.log("GET RESULT", {sql, args, result});
       return result;
     }, cb);
   }
   async all(sql: string, ...args: any[]) {
     const cb = args.pop();
-    console.log("all?", {sql, args});
     handleCallback(async () => {
       const result: any[] = [];
       const cb2 = (v: any) => {
-        console.log("got v", v);
         result.push(v);
       }
       (await this.db).each(sql, args, cb2, () => 1);
-      console.log("done");
       return result;
     }, cb);
   }
@@ -117,9 +108,6 @@ export class Statement {
   private stmt: SqlJs.Statement;
   attach(stmt2: any) {
     this.stmt = stmt2;
-  }
-  foo() {
-    console.log(this.stmt);
   }
   bind(...args: any[]) { throw new Error('nope'); }
   reset(...args: any[]) { throw new Error('nope'); }

--- a/ext/app/server/lib/SqliteJs.ts
+++ b/ext/app/server/lib/SqliteJs.ts
@@ -1,5 +1,7 @@
 import * as SqlJs from 'sql.js';
 import initSqlJs = require('sql.js/dist/sql-wasm-debug');
+
+import { gristOverrides } from 'app/pipe/GristOverrides';
 import { allMarshalQuery, gristMarshal, MinDB, PreparedStatement, SqliteVariant } from 'app/server/lib/SqliteCommon';
 import { OpenMode } from 'app/server/lib/SQLiteDB';
 
@@ -21,7 +23,7 @@ async function getSql() {
   return initSqlJs({
     locateFile: file => {
       let target = `static/sql.js/dist/${file}`;
-      const prefix = typeof window !== 'undefined' && (window as any)?.bootstrapGristPrefix;
+      const prefix = typeof window !== 'undefined' && gristOverrides.bootstrapGristPrefix;
       if (prefix) {
         target = `${prefix}sql.js/dist/${file}`
       }
@@ -38,7 +40,7 @@ export class JsDatabase implements MinDB {
     this.db = new Promise<SqlJs.Database>((resolve, reject) => {
       sql.then(async sql => {
         try {
-          const seedFile = path !== ':memory:' ? (window as any).seedFile : '';
+          const seedFile = path !== ':memory:' ? gristOverrides.seedFile : '';
           let seed: Uint8Array|undefined;
           if (seedFile) {
             const resp = await window.fetch(seedFile);

--- a/ext/app/server/lib/create.ts
+++ b/ext/app/server/lib/create.ts
@@ -1,3 +1,4 @@
+import { gristOverrides } from 'app/pipe/GristOverrides';
 import { makeSimpleCreator, ICreate } from 'app/server/lib/ICreate';
 import { SqliteJsVariant } from 'app/server/lib/SqliteJs';
 import { ISandboxCreationOptions, ISandbox } from 'app/server/lib/ISandbox';
@@ -60,7 +61,7 @@ class PyodideSandbox implements ISandbox {
 
   constructor() {
     const base = document.querySelector('base');
-    const prefix = new URL(((window as any).bootstrapGristPrefix || base?.href || window.location.href));
+    const prefix = new URL(gristOverrides.bootstrapGristPrefix || base?.href || window.location.href);
     const url = getWorkerURL(prefix.href);
     this.workerWrapper = new WorkerWrapper(url);
   }

--- a/ext/app/server/tsconfig.json
+++ b/ext/app/server/tsconfig.json
@@ -14,5 +14,6 @@
   ],
   "references": [
     { "path": "../../../app/common" },
+    { "path": "../pipe" },
   ]
 }

--- a/scripts/build_dist.sh
+++ b/scripts/build_dist.sh
@@ -7,12 +7,12 @@ mkdir dist
 
 ./scripts/link_page_resources.sh copy
 cp -r page/static dist/static
-for f in $(cd page; ls *.grist *.js *.html); do
+for f in $(cd page; ls *.grist *.csv *.html); do
   ln -s ../page/$f dist/$f
 done
 ./scripts/link_page_resources.sh link
 
-cat dist/static/pipe/bootstrap.js | sed "s/^window.bootstrapGristPrefix = .*/window.bootstrapGristPrefix = XXX;/" > dist/latest.js
+cat dist/static/pipe/bootstrap.js | sed "s/^settings.bootstrapGristPrefix = .*/settings.bootstrapGristPrefix = XXX;/" > dist/latest.js
 
 echo "================================================"
 echo "== Prepared dist/static directory"

--- a/scripts/push_next_version.sh
+++ b/scripts/push_next_version.sh
@@ -15,6 +15,10 @@ version="experiments/e$n"
 http="https://grist-static.com/$version/"
 s3url="s3://grist-static/$version"
 
+# remove some unnecessary testing stuff that will make sync fail.
+rm -f dist/static/mocha.js dist/static/mocha.css
+# sync
 aws s3 sync dist/static $s3url
+# point to new version
 cat dist/latest.js | sed "s|XXX|'$http'|" > dist/latest-send.js
 aws s3 cp dist/latest-send.js s3://grist-static/next.js --cache-control max-age=60


### PR DESCRIPTION
Grist Labs publishes a list of custom widgets in the https://github.com/gristlabs/grist-widget repo. This commit implements the /api/widgets endpoint to make these available in the UI in grist-static. There is a CORS issue being addressed in https://github.com/gristlabs/grist-widget/pull/52

Also herded various globals into a single object, as a small step towards sanity.

A few stray deployment tweaks are also included.

The URL for the list of widgets should be made configurable in follow-up.