### PR TITLE
add some test pages for seeing upcoming/previous release

### DIFF
--- a/docs/next.html
+++ b/docs/next.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>grist-static examples</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
+  <script src="https://grist-static.com/next.js"></script>
+</head>
+<body>
+
+<div class="jumbotron text-center">
+  <h1>grist-static</h1>
+  <p>A standalone viewer for <code>.grist</code> files on your website</p>
+</div>
+
+<div class="container">
+  <div class="row mb-5">
+    <div class="col-sm-4">
+      <h3>Example 1</h3>
+      <p><a href="investment-research.html"><img class="img-fluid" src="https://grist-static.com/icons/investment-research.jpg"></a></p>
+      <p><a href="investment-research.html">investment-research.grist</a>, drill down, summarize data.</p>
+    </div>
+    <div class="col-sm-4">
+      <h3>Example 2</h3>
+      <p><a href="flashcards.html"><img class="img-fluid" src="https://grist-static.com/icons/flashcards.jpg"></a></p>
+      <p><a href="flashcards.html">flashcards.grist</a>, using custom widgets.</p>
+    </div>
+    <div class="col-sm-4">
+      <h3>Example 3</h3>
+      <p style="border: 1px solid black;"><a href="blank-slate.html"><img class="img-fluid" src="https://grist-static.com/icons/health-insurance-comparison.jpg" style="opacity: 0.0;"></a></p>
+      <p>A tabula rasa, a <a href="blank-slate.html">blank slate</a> to scribble on.</p>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-sm-4">
+      Use Grist as the PDF of data:
+      <ul>
+        <li>
+          Publish your annual report and
+          interactive spreadsheets side by side.
+        </li>
+        <li>
+          Have the data behind your article on hand for readers
+          to explore.
+        </li>
+      </ul>
+      <p>
+        Learn more: <a href="https://github.com/gristlabs/grist-static">github.com/gristlabs/grist-static</a>
+      </p>
+    </div>
+
+    <div class="col mb-5">
+      <pre id="were-div"><code class="language-html">&lt;!doctype html&gt;
+&lt;html&gt;
+  &lt;head&gt;
+    &lt;meta charset=&quot;utf8&quot;&gt;
+    &lt;script src=&quot;https://grist-static.com/next.js&quot;&gt;&lt;/script&gt;
+    &lt;title&gt;100% browser-based Grist&lt;/title&gt;
+  &lt;/head&gt;
+  &lt;body&gt;
+    &lt;script&gt;
+      bootstrapGrist({
+        initialFile: 'weresheet.grist',   // optional path to .grist
+        name: 'Werewolf Fact Sheet',      // optional name
+        elementId: 'were-div',            // optional element name
+        singlePage: true                  // optional minimalist style
+      });
+    &lt;/script&gt;
+  &lt;/body&gt;
+&lt;/html&gt;</code></pre>
+      <button id="were-click" class="btn btn-primary">Run this code</button>
+    </div>
+  </div>
+
+  <div class="row mb-5">
+    <div class="col-sm-8">
+      <div class="mb-3">
+        We are experimenting with supporting other formats such as
+        CSV. You can specify `initialData` and have a CSV file loaded,
+        with types autodetected.  This is currently slow, since the
+        full Grist data engine must load before you see anything at
+        all, and we haven't optimized that process yet. Watch this
+        space.
+      </div>
+      <pre id="csv-div"><code class="language-html">&lt;!doctype html&gt;
+&lt;html&gt;
+  &lt;head&gt;
+    &lt;meta charset=&quot;utf8&quot;&gt;
+    &lt;script src=&quot;https://grist-static.com/next.js&quot;&gt;&lt;/script&gt;
+  &lt;/head&gt;
+  &lt;body&gt;
+    &lt;script&gt;
+      bootstrapGrist({
+        initialData: 'products.csv',
+        singlePage: true
+      });
+    &lt;/script&gt;
+  &lt;/body&gt;
+&lt;/html&gt;</code></pre>
+      <button id="csv-click" class="btn btn-primary">Run this code</button>
+    </div>
+  </div>
+
+</div>
+
+<script>
+  hljs.highlightAll();
+  document.getElementById('were-click').addEventListener('click', function() {
+    const div = document.getElementById('were-div');
+    div.style.height = '500px';
+    div.style.padding = '0';
+    div.style.border = 'none';
+    div.style.overflow = 'hidden';
+    bootstrapGrist({
+      initialFile: 'weresheet.grist',
+      name: 'Werewolf Fact Sheet',
+      elementId: 'were-div',
+      singlePage: true
+    });
+    document.getElementById('were-click').style.display = 'none';
+    return false;
+  });
+  document.getElementById('csv-click').addEventListener('click', function() {
+    const div = document.getElementById('csv-div');
+    div.style.height = '500px';
+    div.style.padding = '0';
+    div.style.border = '1px solid gray';
+    div.style.overflow = 'hidden';
+    bootstrapGrist({
+      initialData: 'products.csv',
+      elementId: 'csv-div',
+      singlePage: true
+    });
+    document.getElementById('csv-click').style.display = 'none';
+    return false;
+  });
+</script>
+
+</body>
+</html>

--- a/docs/previous.html
+++ b/docs/previous.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>grist-static examples</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
+  <script src="https://grist-static.com/previous.js"></script>
+</head>
+<body>
+
+<div class="jumbotron text-center">
+  <h1>grist-static</h1>
+  <p>A standalone viewer for <code>.grist</code> files on your website</p>
+</div>
+
+<div class="container">
+  <div class="row mb-5">
+    <div class="col-sm-4">
+      <h3>Example 1</h3>
+      <p><a href="investment-research.html"><img class="img-fluid" src="https://grist-static.com/icons/investment-research.jpg"></a></p>
+      <p><a href="investment-research.html">investment-research.grist</a>, drill down, summarize data.</p>
+    </div>
+    <div class="col-sm-4">
+      <h3>Example 2</h3>
+      <p><a href="flashcards.html"><img class="img-fluid" src="https://grist-static.com/icons/flashcards.jpg"></a></p>
+      <p><a href="flashcards.html">flashcards.grist</a>, using custom widgets.</p>
+    </div>
+    <div class="col-sm-4">
+      <h3>Example 3</h3>
+      <p style="border: 1px solid black;"><a href="blank-slate.html"><img class="img-fluid" src="https://grist-static.com/icons/health-insurance-comparison.jpg" style="opacity: 0.0;"></a></p>
+      <p>A tabula rasa, a <a href="blank-slate.html">blank slate</a> to scribble on.</p>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-sm-4">
+      Use Grist as the PDF of data:
+      <ul>
+        <li>
+          Publish your annual report and
+          interactive spreadsheets side by side.
+        </li>
+        <li>
+          Have the data behind your article on hand for readers
+          to explore.
+        </li>
+      </ul>
+      <p>
+        Learn more: <a href="https://github.com/gristlabs/grist-static">github.com/gristlabs/grist-static</a>
+      </p>
+    </div>
+
+    <div class="col mb-5">
+      <pre id="were-div"><code class="language-html">&lt;!doctype html&gt;
+&lt;html&gt;
+  &lt;head&gt;
+    &lt;meta charset=&quot;utf8&quot;&gt;
+    &lt;script src=&quot;https://grist-static.com/previous.js&quot;&gt;&lt;/script&gt;
+    &lt;title&gt;100% browser-based Grist&lt;/title&gt;
+  &lt;/head&gt;
+  &lt;body&gt;
+    &lt;script&gt;
+      bootstrapGrist({
+        initialFile: 'weresheet.grist',   // optional path to .grist
+        name: 'Werewolf Fact Sheet',      // optional name
+        elementId: 'were-div',            // optional element name
+        singlePage: true                  // optional minimalist style
+      });
+    &lt;/script&gt;
+  &lt;/body&gt;
+&lt;/html&gt;</code></pre>
+      <button id="were-click" class="btn btn-primary">Run this code</button>
+    </div>
+  </div>
+
+  <div class="row mb-5">
+    <div class="col-sm-8">
+      <div class="mb-3">
+        We are experimenting with supporting other formats such as
+        CSV. You can specify `initialData` and have a CSV file loaded,
+        with types autodetected.  This is currently slow, since the
+        full Grist data engine must load before you see anything at
+        all, and we haven't optimized that process yet. Watch this
+        space.
+      </div>
+      <pre id="csv-div"><code class="language-html">&lt;!doctype html&gt;
+&lt;html&gt;
+  &lt;head&gt;
+    &lt;meta charset=&quot;utf8&quot;&gt;
+    &lt;script src=&quot;https://grist-static.com/previous.js&quot;&gt;&lt;/script&gt;
+  &lt;/head&gt;
+  &lt;body&gt;
+    &lt;script&gt;
+      bootstrapGrist({
+        initialData: 'products.csv',
+        singlePage: true
+      });
+    &lt;/script&gt;
+  &lt;/body&gt;
+&lt;/html&gt;</code></pre>
+      <button id="csv-click" class="btn btn-primary">Run this code</button>
+    </div>
+  </div>
+
+</div>
+
+<script>
+  hljs.highlightAll();
+  document.getElementById('were-click').addEventListener('click', function() {
+    const div = document.getElementById('were-div');
+    div.style.height = '500px';
+    div.style.padding = '0';
+    div.style.border = 'none';
+    div.style.overflow = 'hidden';
+    bootstrapGrist({
+      initialFile: 'weresheet.grist',
+      name: 'Werewolf Fact Sheet',
+      elementId: 'were-div',
+      singlePage: true
+    });
+    document.getElementById('were-click').style.display = 'none';
+    return false;
+  });
+  document.getElementById('csv-click').addEventListener('click', function() {
+    const div = document.getElementById('csv-div');
+    div.style.height = '500px';
+    div.style.padding = '0';
+    div.style.border = '1px solid gray';
+    div.style.overflow = 'hidden';
+    bootstrapGrist({
+      initialData: 'products.csv',
+      elementId: 'csv-div',
+      singlePage: true
+    });
+    document.getElementById('csv-click').style.display = 'none';
+    return false;
+  });
+</script>
+
+</body>
+</html>

--- a/docs/update.sh
+++ b/docs/update.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Make a version of the test page that uses next.js, to
+# check embedded work before releasing.
+cat index.html | sed "s/latest[.]js/next.js/g" > next.html
+diff index.html next.html
+
+# Allow looking at previous version also (for embedded work).
+cat index.html | sed "s/latest[.]js/previous.js/g" > previous.html
+diff index.html previous.html


### PR DESCRIPTION
This adds two small variants of the main demo page that load from different releases. Just for testing, the pages are not linked from anywhere. Also just for embedded demos, full page demos are not touched.