### PR TITLE
Using parent window fetch to fix FF cookie-based authentication bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ Browsers don't have native support for Grist [yet :-)] but you can make a little
   * You can also pass `initialData: 'path/to/data.csv'` to import a CSV file into a new table. In this case `initialFile` is optional.
   * There is also `initialContent` option. You can use it to pass the content of a CSV file.
   * You can also pass `elementId: 'element-id` to open Grist within an element in your page.
-    - If using `elementId`, and serving a `.grist` or `.csv` file at a URL that requires cookie-based authentication, be aware that Firefox may not support this yet ([bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=1741489)). It
-    can break when your page is itself rendered in an iframe.
 	- In that case, you can include a small wrapper page for your document as above, and embed it as an iframe yourself.
   * You can set `singlePage: true` for a less busy, single page layout.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Browsers don't have native support for Grist [yet :-)] but you can make a little
   * You can also pass `initialData: 'path/to/data.csv'` to import a CSV file into a new table. In this case `initialFile` is optional.
   * There is also `initialContent` option. You can use it to pass the content of a CSV file.
   * You can also pass `elementId: 'element-id` to open Grist within an element in your page.
-    - If using `elementId`, and serving a `.grist` or `.csv` file at a URL that requires cookie-based authentication, be aware that Firefox may not support this yet ([bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=1741489)).
+    - If using `elementId`, and serving a `.grist` or `.csv` file at a URL that requires cookie-based authentication, be aware that Firefox may not support this yet ([bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=1741489)). It
+    can break when your page is itself rendered in an iframe.
 	- In that case, you can include a small wrapper page for your document as above, and embed it as an iframe yourself.
   * You can set `singlePage: true` for a less busy, single page layout.
 

--- a/ext/app/pipe/components.js
+++ b/ext/app/pipe/components.js
@@ -50,11 +50,10 @@
   // Adds a global click handler for elements that should open a Grist document in a popup.
 
   window.addEventListener('click', (clickEvent) => {
-    if (!clickEvent.target.matches('[data-grist-csv-open],[data-grist-doc-open]')) {
-      return;
-    }
+    const target = clickEvent.target?.closest?.('[data-grist-csv-open],[data-grist-doc-open]');
+    if (!target) {return;}
     clickEvent.preventDefault();
-    previewInGristClickHandler(clickEvent.target);
+    previewInGristClickHandler(target);
   });
 
 

--- a/ext/app/server/lib/CommStub.ts
+++ b/ext/app/server/lib/CommStub.ts
@@ -171,6 +171,11 @@ export class Comm  extends dispose.Disposable implements GristServerAPI, DocList
   }
 
   private async _loadInitialData(initialDataUrl: string) {
+    // If we are in a iframe, we need to use the parent window to fetch the data.
+    // This is hack to fix a bug in FF https://bugzilla.mozilla.org/show_bug.cgi?id=1741489, and shouldn't
+    // affect other browsers.
+    // TODO: add test for it.
+    const fetch = (window.parent === window) ? window.fetch : window.parent.fetch;
     const response = await fetch(initialDataUrl);
     if (!response.ok) {
       throw new Error(`Failed to load initial data from ${initialDataUrl}: ${response.statusText}`);

--- a/ext/app/server/lib/CommStub.ts
+++ b/ext/app/server/lib/CommStub.ts
@@ -175,7 +175,8 @@ export class Comm  extends dispose.Disposable implements GristServerAPI, DocList
     // This is hack to fix a bug in FF https://bugzilla.mozilla.org/show_bug.cgi?id=1741489, and shouldn't
     // affect other browsers.
     // TODO: add test for it.
-    const fetch = (window.parent === window) ? window.fetch : window.parent.fetch;
+    const inSrcDoc = Boolean(window.frameElement?.getAttribute('srcdoc'));
+    const fetch = inSrcDoc ? window.parent.fetch : window.fetch;
     const response = await fetch(initialDataUrl);
     if (!response.ok) {
       throw new Error(`Failed to load initial data from ${initialDataUrl}: ${response.statusText}`);

--- a/ext/app/server/lib/SqliteJs.ts
+++ b/ext/app/server/lib/SqliteJs.ts
@@ -43,7 +43,12 @@ export class JsDatabase implements MinDB {
           const seedFile = path !== ':memory:' ? gristOverrides.seedFile : '';
           let seed: Uint8Array|undefined;
           if (seedFile) {
-            const resp = await window.fetch(seedFile);
+            // If we are in a iframe, we need to use the parent window to fetch the data.
+            // This is hack to fix a bug in FF https://bugzilla.mozilla.org/show_bug.cgi?id=1741489, and shouldn't
+            // affect other browsers.
+            // TODO: add test for it.
+            const fetch = (window.parent === window) ? window.fetch : window.parent.fetch;
+            const resp = await fetch(seedFile);
             if (!resp.ok) {
               throw new Error(seedFile + ": " + resp.statusText);
             }

--- a/ext/app/server/lib/SqliteJs.ts
+++ b/ext/app/server/lib/SqliteJs.ts
@@ -47,7 +47,8 @@ export class JsDatabase implements MinDB {
             // This is hack to fix a bug in FF https://bugzilla.mozilla.org/show_bug.cgi?id=1741489, and shouldn't
             // affect other browsers.
             // TODO: add test for it.
-            const fetch = (window.parent === window) ? window.fetch : window.parent.fetch;
+            const inSrcDoc = Boolean(window.frameElement?.getAttribute('srcdoc'));
+            const fetch = inSrcDoc ? window.parent.fetch : window.fetch;
             const resp = await fetch(seedFile);
             if (!resp.ok) {
               throw new Error(seedFile + ": " + resp.statusText);

--- a/page/index_custom.html
+++ b/page/index_custom.html
@@ -18,6 +18,12 @@
 
 
   <p>
+    Here is anchor with an image <a data-grist-doc-open="./investment-research.grist" href="#" data-name="Students" data-single-page>
+      <img src="https://picsum.photos/100/50" />
+    </a> as well.
+  </p>
+
+  <p>
     There is a <button data-grist-doc-open="investment-research.grist" data-name="Students" data-single-page>button</button> variant.
   </p>
 


### PR DESCRIPTION
This is hack to fix a bug in FF https://bugzilla.mozilla.org/show_bug.cgi?id=1741489. It is using parent's window fetch function what seems to fix the problem