### PR TITLE
Move 'powered by' message to the center bottom, to avoid overlappign …

### DIFF
--- a/ext/app/pipe/components.js
+++ b/ext/app/pipe/components.js
@@ -179,7 +179,7 @@
     #grist-viewer-popup .grist-powered-by {
       position: absolute;
       bottom: 28px;
-      right: 48px;
+      width: 100%;
       line-height: 20px;
       font-size: 12px;
       color: #d9d9d9;


### PR DESCRIPTION
…with things like beacons in page corners