### PR TITLE
include pyodide bundle in grist-static again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ requirements:
 	cd core && yarn run install:python
 	cd core/sandbox/pyodide && make setup
 	cd core/sandbox && ./bundle_as_wheel.sh && cp dist/*.whl pyodide/_build/packages/
+	node scripts/pyodide-pyc-ify.js
 
 update-lock:
 	cd ext && yarn install --modules-folder=../node_modules --verbose

--- a/ext/app/pipe/webworker.js
+++ b/ext/app/pipe/webworker.js
@@ -21,7 +21,7 @@ self.callExternal = (name, args) => {
 }
 
 async function initPyodide() {
-  const pyodide = await loadPyodide({indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.23.4/pyc/'});
+  const pyodide = await loadPyodide({indexURL: self.urlPrefix + "pyodide/"});
   console.log(pyodide.runPython(`
 import sys
 sys.version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grist-static",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "A purely front-end flavor of Grist",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/build_dist.sh
+++ b/scripts/build_dist.sh
@@ -20,6 +20,11 @@ done
 # Remove some unnecessary symlinks that will make s3 syncs fail.
 rm -f dist/mocha.js dist/mocha.css
 
+# Remove some duplicates of sql.js not used in front-end.
+rm -rf dist/static/sql.js/dist/
+rm -rf dist/node_modules/sql.js/dist/
+rm -f dist/sql.js/dist/sqljs-all.zip
+
 # Move entry points to top level of dist.
 for f in components.js csv-viewer.js; do
   cp dist/pipe/$f dist

--- a/scripts/link_page_resources.sh
+++ b/scripts/link_page_resources.sh
@@ -60,6 +60,7 @@ cd pipe
 transfer ./ ../../../ext/app/pipe/bootstrap.js bootstrap.js
 transfer ./ ../../../ext/app/pipe/components.js components.js
 transfer ./ ../../../ext/app/pipe/csv-viewer.js csv-viewer.js
+transfer ./ ../../../node_modules/pyodide pyodide
 transfer ../../../core/app/server/ ../../sandbox/pyodide/_build/packages packages
 cd ..
 

--- a/scripts/pyodide-pyc-ify.js
+++ b/scripts/pyodide-pyc-ify.js
@@ -42,9 +42,8 @@ async function scanFiles() {
   for (const f of files) {
     const src = indexURL + f;
     console.log(`checking for version of ${f} at ${src}`);
-    const head = await fetch(src, { method: 'HEAD' });
-    if (head.ok) {
-      const fileResponse = await fetch(src);
+    const fileResponse = await fetch(src);
+    if (fileResponse.ok) {
       const fileBuffer = await fileResponse.buffer();
       const outputFile = path.join(base, f);
       fs.writeFileSync(outputFile, fileBuffer);

--- a/scripts/pyodide-pyc-ify.js
+++ b/scripts/pyodide-pyc-ify.js
@@ -1,0 +1,57 @@
+/**
+ * pyodide has a pyc version we'd like to use, currently at:
+ *   https://cdn.jsdelivr.net/pyodide/v0.23.4/pyc/
+ * Unlike the rest of pyodide, the version isn't available in
+ * github releases or other packaged forms that I can find,
+ * so we play some tricks to fetch it.
+ *
+ * (We could do simply:
+ *   loadPyodide({indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.23.4/pyc/'})
+ * but then grist-static wouldn't be usable at all without a network, and
+ * we'd need to document the extra dependency).
+ */
+
+const fs = require('fs');
+const fetch = require('node-fetch');
+const path = require('path');
+
+// Regular pyodide release is stored here.
+const base = 'node_modules/pyodide';
+
+// Scan pyodide release, and replace any files with a "pyc" version.
+async function scanFiles() {
+  const packageFile = path.join(base, 'package.json');
+  const data = fs.readFileSync(packageFile, 'utf8');
+  const packageJson = JSON.parse(data);
+  const version = packageJson.version;
+
+  console.log(`pyodide version ${version}`);
+
+  const checkFile = path.join(base, `checked-${version}.txt`);
+  if (fs.existsSync(checkFile)) {
+    const packageTime = fs.statSync(packageFile).mtime;
+    const checkTime = fs.statSync(checkFile).mtime;
+    if (packageTime <= checkTime) {
+      console.log('already converted to pyc');
+      return;
+    }
+  }
+
+  const indexURL = `https://cdn.jsdelivr.net/pyodide/v${version}/pyc/`;
+  const files = fs.readdirSync(base);
+  for (const f of files) {
+    const src = indexURL + f;
+    console.log(`checking for version of ${f} at ${src}`);
+    const head = await fetch(src, { method: 'HEAD' });
+    if (head.ok) {
+      const fileResponse = await fetch(src);
+      const fileBuffer = await fileResponse.buffer();
+      const outputFile = path.join(base, f);
+      fs.writeFileSync(outputFile, fileBuffer);
+      console.log(`Wrote to ${outputFile}`);
+    }
+  }
+  fs.writeFileSync(checkFile, '');
+}
+
+scanFiles().catch(e => console.error(e));


### PR DESCRIPTION
This bundles pyodide with grist-static again, similar to how it was prior to https://github.com/gristlabs/grist-static/pull/19. It runs a (somewhat clunky) script to replace pyodide assets with versions in the "pyc" release.