### PR TITLE
hook up csv, xlsx, and .grist downloads

### DIFF
--- a/ext/app/client/HookStub.ts
+++ b/ext/app/client/HookStub.ts
@@ -121,6 +121,10 @@ async function fetchFromDocApi(href: string): Promise<DownloadInfo> {
     // Not expected.
     throw new Error('fetchFromDocApi needs homeUrl');
   }
+  if (!href.startsWith(config.homeUrl)) {
+    // Not expected.
+    throw new Error('Endpoint does not have expected base URL');
+  }
   const pathname = '/' + href.split(config.homeUrl)[1];
 
   // Use a simulated router to run the "back-end" code.

--- a/ext/app/client/HookStub.ts
+++ b/ext/app/client/HookStub.ts
@@ -101,7 +101,7 @@ interface DownloadInfo {
  */
 async function downloadInBrowser(downloadInfo: DownloadInfo) {
   const {data, name, type} = downloadInfo;
-  const blob = new Blob([data], { type });
+  const blob = new Blob([data], {type});
   const url = window.URL.createObjectURL(blob);
   const link = document.createElement('a');
   link.href = url;

--- a/ext/app/client/HookStub.ts
+++ b/ext/app/client/HookStub.ts
@@ -1,5 +1,6 @@
 import { defaultHooks, IHooks } from 'app/client/DefaultHooks';
 import { IGristUrlState } from 'app/common/gristUrls';
+import { getGristConfig } from 'app/common/urlUtils';
 import { gristOverrides } from 'app/pipe/GristOverrides';
 
 export const hooks: IHooks = {
@@ -13,8 +14,8 @@ export const hooks: IHooks = {
     postEncode,
     preDecode,
   },
+  link,
 };
-console.log({hooks});
 
 function fetcher(...args: any[]) {
   if ((window as any).fetchHook) {
@@ -80,4 +81,105 @@ function postEncode(options: {
   }
   at.hash = url.hash;
   url.href = at.href;
+}
+
+/**
+ * Information about a download the user has requested.
+ */
+interface DownloadInfo {
+  data: any;     // The body of the response.
+  name: string;  // A name assigned in a header or elsewhere.
+  type: string;  // The mime type associated with the body.
+}
+
+/**
+ * Trigger a download of some prepared data in the browser.
+ * Must be called ultimately by a user clicking on a link
+ * or button, or the browser will deny a simulated click
+ * used in the implementation.
+ */
+async function downloadInBrowser(downloadInfo: DownloadInfo) {
+  const {data, name, type} = downloadInfo;
+  const blob = new Blob([data], { type });
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = name;
+  link.click();
+  window.URL.revokeObjectURL(url);
+}
+
+/**
+ * Given a URL of some document API REST endpoint, call
+ * the "back-end" code for it, and then try to determine
+ * the name and type (and content) of the response.
+ */
+async function fetchFromDocApi(href: string): Promise<DownloadInfo> {
+  // Figure out the path relative to the home URL
+  const config = getGristConfig();
+  if (!config?.homeUrl) {
+    // Not expected.
+    throw new Error('fetchFromDocApi needs homeUrl');
+  }
+  const pathname = '/' + href.split(config.homeUrl)[1];
+
+  // Use a simulated router to run the "back-end" code.
+  const app = gristOverrides.expressApp;
+  if (!app) {
+    // Not expected.
+    throw new Error('fetchFromDocApi needs expressApp');
+  }
+  const res = await app.run({
+    method: 'get',
+    path: pathname,
+  });
+
+  // Rifle through the information returned to find a name
+  // and type.
+  // A name may be provided in a Content-Disposition header
+  // of the form 'attachment; filename="name.csv"'
+  // or by a call to res.download
+  const prefix = 'attachment; filename="';
+  let name = String(res.headers?.['Content-Disposition'] || '');
+  if (name.startsWith(prefix)) {
+    name = name.slice(prefix.length, name.length - 1);
+  }
+  name = name || res.name || 'download';
+
+  // A type may be provided in a Content-Type header
+  // or by a call to res.download
+  const type = res.type || res.sets['Content-Type'] || 'application/octet-stream';
+
+  return {data: res.data, name, type};
+}
+
+async function fetchAndDownload(element: any) {
+  const href = element.href;
+  if (!href) {
+    // Not expected.
+    throw new Error('fetchAndDownload needs href');
+  }
+  const downloadInfo = await fetchFromDocApi(href);
+  await downloadInBrowser(downloadInfo);
+}
+
+function gristDownloadLink(element: any) {
+  fetchAndDownload(element).catch(e => console.error(e));
+  return false;
+}
+
+(window as any).gristDownloadLink = gristDownloadLink;
+
+/**
+ * Redirect download links to a new, in-browser implementation.
+ */
+function link(originalLink: Record<string, any>) {
+  if (originalLink.download === undefined) {
+    return originalLink;
+  }
+  const newLink = {...originalLink};
+  newLink.onclick = "return gristDownloadLink(this)";
+  delete newLink.target;
+  delete newLink.download;
+  return newLink;
 }

--- a/ext/app/client/HookStub.ts
+++ b/ext/app/client/HookStub.ts
@@ -2,6 +2,7 @@ import { defaultHooks, IHooks } from 'app/client/DefaultHooks';
 import { IGristUrlState } from 'app/common/gristUrls';
 import { getGristConfig } from 'app/common/urlUtils';
 import { gristOverrides } from 'app/pipe/GristOverrides';
+import { IAttrObj } from 'grainjs';
 
 export const hooks: IHooks = {
   ...defaultHooks,
@@ -14,7 +15,7 @@ export const hooks: IHooks = {
     postEncode,
     preDecode,
   },
-  link,
+  maybeModifyLinkAttrs,
 };
 
 function fetcher(...args: any[]) {
@@ -173,13 +174,13 @@ function gristDownloadLink(element: any) {
 /**
  * Redirect download links to a new, in-browser implementation.
  */
-function link(originalLink: Record<string, any>) {
-  if (originalLink.download === undefined) {
-    return originalLink;
+function maybeModifyLinkAttrs(originalAttrs: IAttrObj) {
+  if (originalAttrs.download === undefined) {
+    return originalAttrs;
   }
-  const newLink = {...originalLink};
-  newLink.onclick = "return gristDownloadLink(this)";
-  delete newLink.target;
-  delete newLink.download;
-  return newLink;
+  const newAttrs = {...originalAttrs};
+  newAttrs.onclick = "return gristDownloadLink(this)";
+  delete newAttrs.target;
+  delete newAttrs.download;
+  return newAttrs;
 }

--- a/ext/app/client/HookStub.ts
+++ b/ext/app/client/HookStub.ts
@@ -99,8 +99,7 @@ interface DownloadInfo {
  * or button, or the browser will deny a simulated click
  * used in the implementation.
  */
-async function downloadInBrowser(downloadInfo: DownloadInfo) {
-  const {data, name, type} = downloadInfo;
+async function downloadInBrowser({data, name, type}: DownloadInfo) {
   const blob = new Blob([data], {type});
   const url = window.URL.createObjectURL(blob);
   const link = document.createElement('a');
@@ -143,6 +142,7 @@ async function fetchFromDocApi(href: string): Promise<DownloadInfo> {
   const prefix = 'attachment; filename="';
   let name = String(res.headers?.['Content-Disposition'] || '');
   if (name.startsWith(prefix)) {
+    // Remove the prefix and the closing double quote
     name = name.slice(prefix.length, name.length - 1);
   }
   name = name || res.name || 'download';

--- a/ext/app/pipe/GristOverrides.ts
+++ b/ext/app/pipe/GristOverrides.ts
@@ -24,6 +24,9 @@ export interface GristOverrides {
   fakeUrl?: string;
   fakeDocId?: string;
   singlePage?: boolean;
+
+  // A hook to the document's REST API.
+  expressApp?: MiniExpress;
 }
 
 export function getGristOverrides(): GristOverrides {
@@ -32,3 +35,32 @@ export function getGristOverrides(): GristOverrides {
 }
 
 export const gristOverrides = getGristOverrides();
+
+/**
+ * A bare-bones implementation of Express. Call run with a http request
+ * method and path (e.g. /api/docs/DOCID/download/xlsx), and get back
+ * information about what the "back-end" code for that endpoint did.
+ */
+export interface MiniExpress {
+  run(options: {method: string, path: string}): Promise<ResponseInfo>;
+}
+
+/**
+ * A grab-bag of information about a response.
+ */
+export interface ResponseInfo {
+  // Keeps track of any res.set(key, val) calls.
+  sets: Record<string, any>;
+
+  // Keeps track of any res.setHeader(key, val) calls.
+  headers: Record<string, any>;
+
+  // Keeps track of material from a res.send() or a res.download().
+  data: any;
+
+  // Keeps track of a res.type() call.
+  type?: string;
+
+  // Set from a res.download() call.
+  name?: string;
+}

--- a/ext/app/pipe/bootstrap.js
+++ b/ext/app/pipe/bootstrap.js
@@ -82,43 +82,43 @@ function bootstrapGrist(options) {
   } else if (options.initialData) {
     settings.initialData = options.initialData;
   }
-  const fakeDocId = "new~2d6rcxHotohxAuTxttFRzU";
-  const fakeUrl = "https://example.com/o/docs/doc/new~2d6rcxHotohxAuTxttFRzU";
+  const fakeDocId = "new~tTzg3iGWsXq7Q6hSXGb94j";
+  const fakeUrl = `https://example.com/o/docs/doc/${fakeDocId}`;
   settings.fakeUrl = fakeUrl;
   settings.fakeDocId = fakeDocId;
   if (options.singlePage) {
     settings.singlePage = Boolean(options.singlePage);
   }
   window.gristConfig = {
-    "homeUrl":homeUrl,
-    "org":"docs",
-    "baseDomain":null,
-    "singleOrg":null,
-    "helpCenterUrl":"https://support.getgrist.com",
-    "pathOnly":true,
-    "supportAnon":false,
-    "supportEngines":null,
-    "hideUiElements":["helpCenter", "billing", "templates", "multiSite", "multiAccounts"],
-    "pageTitleSuffix":null,
-    "pluginUrl":"http://plugins.invalid",
-    "stripeAPIKey":null,
-    "googleClientId":null,
-    "googleDriveScope":null,
-    "helpScoutBeaconId":null,
-    "maxUploadSizeImport":null,
-    "maxUploadSizeAttachment":null,
-    "timestampMs":1678573297305,
-    "enableWidgetRepository":true,
-    "survey":false,
-    "tagManagerId":null,
-    "activation":{"isManager":false},
-    "enableCustomCss":false,
-    "supportedLngs":["de","en","es","fr","nb_NO","pt_BR"],
-    "namespaces":["client","server"],
-    "featureComments":false,
-    "supportEmail":"support@getgrist.com",
-    "assignmentId":"new~2d6rcxHotohxAuTxttFRzU",
-    "plugins":[]
+    "homeUrl": homeUrl,
+    "org": "docs",
+    "baseDomain": null,
+    "singleOrg": null,
+    "helpCenterUrl": "https://support.getgrist.com",
+    "pathOnly": true,
+    "supportAnon": false,
+    "supportEngines": null,
+    "hideUiElements": ["helpCenter", "billing", "templates", "multiSite", "multiAccounts"],
+    "pageTitleSuffix": null,
+    "pluginUrl": "http://plugins.invalid",
+    "stripeAPIKey": null,
+    "googleClientId": null,
+    "googleDriveScope": null,
+    "helpScoutBeaconId": null,
+    "maxUploadSizeImport": null,
+    "maxUploadSizeAttachment": null,
+    "timestampMs": 1678573297305,
+    "enableWidgetRepository": true,
+    "survey": false,
+    "tagManagerId": null,
+    "activation": {"isManager":false},
+    "enableCustomCss": false,
+    "supportedLngs": ["de","en","es","fr","nb_NO","pt_BR"],
+    "namespaces": ["client","server"],
+    "featureComments": false,
+    "supportEmail": "support@getgrist.com",
+    "assignmentId": fakeDocId,
+    "plugins": []
   };
 
   const css = [

--- a/ext/app/pipe/components.js
+++ b/ext/app/pipe/components.js
@@ -67,7 +67,11 @@
 
     const csvNode = document.createElement('csv-viewer');
     csvNode.setAttribute(initAttribute, href);
-    csvNode.setAttribute('name', name);
+    // Pass along name attribute only if set (be careful not to set it
+    // to the string 'null')
+    if (name) {
+      csvNode.setAttribute('name', name);
+    }
     csvNode.setAttribute('style', 'flex: 1');
     if (options.loader !== false) {
       csvNode.setAttribute('loader', '');

--- a/ext/app/server/Doc.ts
+++ b/ext/app/server/Doc.ts
@@ -1,16 +1,19 @@
 // Enough to work with a single document in a browser
 
-//import {Comm} from 'app/server/lib/Comm';
-//import * as sqlite3 from 'app/server/lib/SQLite';
-import {SQLiteDB} from 'app/server/lib/SQLiteDB';
-//import {sql, Database} from 'app/server/lib/SQLite';
-import {DocStorage} from 'app/server/lib/DocStorage';
-//import {DocStorageManager} from 'app/server/lib/DocStorageManager';
+import {gristOverrides, MiniExpress, ResponseInfo} from 'app/pipe/GristOverrides';
 import {ActiveDoc, Deps as ActiveDocDeps} from 'app/server/lib/ActiveDoc';
-import {DocManager} from 'app/server/lib/DocManager';
-import {NSandbox} from 'app/server/lib/NSandbox';
-
+import {Comm} from 'app/server/lib/Comm';
 import {create} from 'app/server/lib/create';
+import {addDocApiRoutes} from 'app/server/lib/DocApi';
+import {DocManager} from 'app/server/lib/DocManager';
+import {DocStorage} from 'app/server/lib/DocStorage';
+import {DocWorker} from 'app/server/lib/DocWorker';
+import {GristServer} from 'app/server/lib/GristServer';
+import {HomeDBManager} from 'app/server/lib/HomeDBManagerStub';
+import {NSandbox} from 'app/server/lib/NSandbox';
+import {SQLiteDB} from 'app/server/lib/SQLiteDB';
+import {virtualFileSystem} from 'app/server/lib/SqliteJs';
+
 
 process.env.GRIST_SANDBOX_FLAVOR = 'pyodideInline';
 
@@ -29,11 +32,220 @@ class FakeDocStorageManager {
   closeDocument() {}
   prepareLocalDoc() {}
   makeBackup() {}
+
+  /**
+   * Copies are made when filtering a document
+   * prior to downloading as a .grist file.
+   * We support exactly one copy, called 'copy',
+   * And conspire with SqliteJs so that works
+   * just well enough.
+   */
+  getCopy() {
+    virtualFileSystem.delete('copy');
+    return 'copy';
+  }
 }
 
 // A simple test function for when things go wrong.
 function get42() {
   return 42;
+}
+
+/**
+ * A minimal implementation of Express, to be able to access
+ * the document REST API.
+ */
+export class MiniExpressImpl implements MiniExpress {
+  private _endpoints: Endpoint[] = [];
+
+  // Methods for adding endpoints.
+
+  public post(...args: any[]) {
+    this._addEndpoint('post', args);
+  }
+  public get(...args: any[]) {
+    this._addEndpoint('get', args);
+  }
+  public patch(...args: any[]) {
+    this._addEndpoint('patch', args);
+  }
+  public delete(...args: any[]) {
+    this._addEndpoint('delete', args);
+  }
+  public put(...args: any[]) {
+    this._addEndpoint('put', args);
+  }
+
+  // Method for invoking an endpoint.
+
+  public async run(options: {method: string, path: string}): Promise<ResponseInfo> {
+    // Look up the endpoint.
+    const endpointAndParams = this._getEndpoint(options);
+    if (!endpointAndParams) {
+      throw new Error('cannot find ' + String(options));
+    }
+
+    // For now, it seems to be fine to just take the last function and
+    // skip middleware entirely. In principle, some middleware could set a
+    // value that we need, but in practice that isn't the case for the
+    // endpoints we're using so far.
+    const fns = endpointAndParams.endpoint.fns;
+    const fn = fns[fns.length - 1];
+
+    // Extract query parameters in expected format.
+    const url = new URL(options.path, 'http://localhost');
+    const query = {} as Record<string, string>;
+    for (const [k, v] of url.searchParams.entries()) {
+      query[k] = v;
+    }
+
+    // Build up something sufficently like an Express request object
+    // for the endpoints we are using.
+    const req = {
+      get(key: string): any {
+        return null;
+      },
+      userId: 1,
+      user: {
+        id: 1,
+        name: 'User',
+      },
+      docAuth: {
+        docId: gristOverrides.fakeDocId || 'unknown',
+        access: 'owners',
+        cachedDoc: {
+          workspace: {
+            org: {
+            }
+          }
+        }
+      },
+      query,
+      params: endpointAndParams.params,
+    };
+
+    // Create a place to cache information set in a response.
+    const info: ResponseInfo = {
+      sets: {},
+      headers: {},
+      data: undefined,
+    };
+
+    // Build up something sufficently like an Express response object
+    // for the endpoints we are using.
+    const res = {
+      set(key: string, val: any) {
+        info.sets[key] = val;
+        return this;
+      },
+      setHeader(key: string, val: any) {
+        info.headers[key] = val;
+        return this;
+      },
+      send(data: any) {
+        info.data = data;
+        return this;
+      },
+      type(name: string) {
+        info.type = name;
+        return this;
+      },
+      download(fileName: string, name: string, fn: (err: any) => Promise<void>) {
+        info.name = name;
+        info.data = virtualFileSystem.get(fileName);
+      }
+    };
+    const next = (err?: any) => {
+      if (err) {
+        throw err;
+      }
+    }
+    await fn(req, res, next);
+    return info;
+  }
+
+  // Helpers.
+
+  /**
+   * Match a path against a template, like:
+   *    /api/workspaces/abc123/import
+   * against:
+   *    /api/workspaces/:wid/import'
+   * Returns undefined if no match, otherwise an object with the
+   * required parameters to make the match.
+   */
+  private _matchPath(fullPath: string, template: string): Record<string, string>|undefined {
+    const url = new URL(fullPath, 'http://localhost');
+    const path = url.pathname;
+
+    const pathSegments = path.split('/');
+    const templateSegments = template.split('/');
+
+    if (pathSegments.length !== templateSegments.length) {
+      return undefined;
+    }
+
+    const params: Record<string, string> = {};
+    for (let i = 0; i < pathSegments.length; i++) {
+      const pathSegment = pathSegments[i];
+      const templateSegment = templateSegments[i];
+      if (templateSegment.startsWith(':')) {
+        const paramName = templateSegment.slice(1);
+        params[paramName] = pathSegment;
+      } else if (pathSegment !== templateSegment) {
+        return undefined;
+      }
+    }
+    return params;
+  }
+
+  private _addEndpoint(method: string, args: any[]) {
+    const path = args[0];
+    if (typeof path !== 'string') {
+      throw new Error('do not know what to do with ' + String(path));
+    }
+    const fns = args.slice(1);
+    this._endpoints.push({method, path, fns});
+  }
+
+  private _getEndpoint(options: {method: string, path: string}) {
+    for (const endpoint of this._endpoints) {
+      if (endpoint.method !== options.method) { continue; }
+      const params = this._matchPath(options.path, endpoint.path);
+      if (!params) { continue; }
+      return { endpoint, params };
+    }
+  }
+}
+
+// Express-like middleware functions.
+type ExpressFn = (req: any, res: any, err: any) => Promise<any>;
+
+// A per-endpoint record.
+interface Endpoint {
+  method: string;
+  path: string;
+  fns: ExpressFn[];
+}
+
+/**
+ * Construct an express-like app.
+ */
+function makeApp(dm: DocManager, gs: GristServer, comm: Comm): MiniExpress {
+  const app = new MiniExpressImpl();
+  const db = new HomeDBManager();
+  const dw = new DocWorker(db as any, {
+    comm,
+    gristServer: gs
+  });
+
+  addDocApiRoutes(app as any,
+                  dw,
+                  {} as any,
+                  dm,
+                  db as any,
+                  gs);
+  return app;
 }
 
 const backend = {
@@ -49,6 +261,7 @@ const backend = {
   DocManager,
   NSandbox,
   create,
+  makeApp,
 };
 
 export default backend;

--- a/ext/app/server/lib/ExportXLSXStub.ts
+++ b/ext/app/server/lib/ExportXLSXStub.ts
@@ -1,0 +1,14 @@
+import * as workerExporter from 'app/server/lib/workerExporter';
+import { ActiveDoc } from 'app/server/lib/ActiveDoc';
+import * as express from 'express';
+import {Writable} from 'stream';
+import {ExportParameters} from 'app/server/lib/Export';
+import { ActiveDocSourceDirect } from 'app/server/lib/Export';
+
+export async function streamXLSX(activeDoc: ActiveDoc, req: express.Request,
+                                 outputStream: Writable, options: ExportParameters) {
+  const testDates = (req.hostname === 'localhost');
+  const activeDocSource = new ActiveDocSourceDirect(activeDoc, req);
+  const result = await workerExporter.doMakeXLSXFromOptions(activeDocSource, testDates, undefined as any, options);
+  (outputStream as any).send(result);
+}

--- a/ext/app/server/lib/GoogleAuthStub.ts
+++ b/ext/app/server/lib/GoogleAuthStub.ts
@@ -1,0 +1,7 @@
+export const foo = 12;
+
+export function googleAuthTokenMiddleware(fn: any) { return fn; }
+
+export function exportToDrive() {
+  console.error("exportToDrive not implemented");
+}

--- a/ext/app/server/lib/HomeDBManagerStub.ts
+++ b/ext/app/server/lib/HomeDBManagerStub.ts
@@ -1,0 +1,37 @@
+import { ApiError } from "app/common/ApiError";
+import { GristLoadConfig } from "app/common/gristUrls";
+import * as roles from 'app/common/roles';
+import { GristOverrides } from "app/pipe/GristOverrides";
+
+
+export class HomeDBManager {
+  public async getDoc(reqOrScope: any) {
+    const config = (window as any).gristConfig as GristLoadConfig;
+    const overrides = (window as any).gristOverrides as GristOverrides;
+    return {
+      id: config.assignmentId,
+      name: overrides.staticGristOptions?.name || 'grist',
+    };
+  }
+}
+
+export async function makeDocAuthResult(docPromise: Promise<any>): Promise<DocAuthResult> {
+  try {
+    const doc = await docPromise;
+    const removed = Boolean(doc.removedAt || doc.workspace.removedAt);
+    return {docId: doc.id, access: doc.access, removed, cachedDoc: doc};
+  } catch (error) {
+    return {docId: null, access: null, removed: null, error};
+  }
+}
+
+
+// TODO: factor out
+export interface DocAuthResult {
+  docId: string|null;         // The unique identifier of the document. Null on error.
+  access: roles.Role|null;    // The access level for the requesting user. Null on error.
+  removed: boolean|null;      // Set if the doc is soft-deleted. Users may still have access
+                              // to removed documents for some purposes. Null on error.
+  error?: ApiError;
+  cachedDoc?: any;       // For cases where stale info is ok.
+}

--- a/ext/app/server/lib/HomeDBManagerStub.ts
+++ b/ext/app/server/lib/HomeDBManagerStub.ts
@@ -3,7 +3,10 @@ import { GristLoadConfig } from "app/common/gristUrls";
 import * as roles from 'app/common/roles';
 import { GristOverrides } from "app/pipe/GristOverrides";
 
-
+/**
+ * Bare minimum HomeDBManager that implements getDoc - this is enough
+ * for the DocApi endpoints we are using so far.
+ */
 export class HomeDBManager {
   public async getDoc(reqOrScope: any) {
     const config = (window as any).gristConfig as GristLoadConfig;
@@ -15,23 +18,29 @@ export class HomeDBManager {
   }
 }
 
+/**
+ * Bare minimum function for extracting a DocAuthResult.
+ * We don't have any security concerns, so just put
+ * an "owners" access level on the doc.
+ */
 export async function makeDocAuthResult(docPromise: Promise<any>): Promise<DocAuthResult> {
   try {
     const doc = await docPromise;
-    const removed = Boolean(doc.removedAt || doc.workspace.removedAt);
-    return {docId: doc.id, access: doc.access, removed, cachedDoc: doc};
+    return {docId: doc.id, access: 'owners', removed: false, cachedDoc: doc};
   } catch (error) {
     return {docId: null, access: null, removed: null, error};
   }
 }
 
-
-// TODO: factor out
+// TODO: ideally pull this out of grist-core HomeDBManager.
+// For the moment, I need to avoid including that, since I'm
+// not ready to deal with a second SQLite database, and we
+// really don't need the Home DB yet, we just need enough to
+// be able to fake getDoc calls.
 export interface DocAuthResult {
-  docId: string|null;         // The unique identifier of the document. Null on error.
-  access: roles.Role|null;    // The access level for the requesting user. Null on error.
-  removed: boolean|null;      // Set if the doc is soft-deleted. Users may still have access
-                              // to removed documents for some purposes. Null on error.
+  docId: string|null;
+  access: roles.Role|null;
+  removed: boolean|null;
   error?: ApiError;
-  cachedDoc?: any;       // For cases where stale info is ok.
+  cachedDoc?: any;
 }

--- a/ext/app/server/lib/piscina-stub.ts
+++ b/ext/app/server/lib/piscina-stub.ts
@@ -1,0 +1,9 @@
+import * as workerExporter from 'app/server/lib/workerExporter';
+
+class PiscinaStub {
+  public static isWorkerThread = false;
+}
+
+console.log(workerExporter);
+
+export default PiscinaStub;

--- a/ext/app/server/lib/piscina-stub.ts
+++ b/ext/app/server/lib/piscina-stub.ts
@@ -1,5 +1,3 @@
-import * as workerExporter from 'app/server/lib/workerExporter';
-
 class PiscinaStub {
   public static isWorkerThread = false;
 }

--- a/ext/app/server/lib/piscina-stub.ts
+++ b/ext/app/server/lib/piscina-stub.ts
@@ -4,6 +4,4 @@ class PiscinaStub {
   public static isWorkerThread = false;
 }
 
-console.log(workerExporter);
-
 export default PiscinaStub;

--- a/ext/buildtools/webpack.config.js
+++ b/ext/buildtools/webpack.config.js
@@ -27,8 +27,14 @@ base.resolve.alias = {
   'child_process': 'app/server/lib/childProcessStub',
   'tmp': 'app/server/lib/tmpStub',
   'app/client/components/Comm': 'app/server/lib/CommStub',
-  'app/server/utils/ProxyAgent': 'app/server/lib/ProxyAgentStub',
+  'app/server/lib/ProxyAgent': 'app/server/lib/ProxyAgentStub',
   'app/client/Hooks': 'app/client/HookStub',
+  'app/gen-server/lib/HomeDBManager': 'app/server/lib/HomeDBManagerStub',
+  'piscina': 'app/server/lib/piscina-stub',
+  'app/server/lib/GoogleAuth': 'app/server/lib/GoogleAuthStub',
+  'app/server/lib/GoogleExport': 'app/server/lib/GoogleAuthStub',
+  'app/server/lib/ExportXLSX': 'app/server/lib/ExportXLSXStub',
+  'exceljs': 'exceljs/dist/es5/exceljs.browser.js',
 };
 
 base.resolve.fallback = {

--- a/ext/buildtools/webpack.config.js
+++ b/ext/buildtools/webpack.config.js
@@ -58,6 +58,19 @@ base.resolve.fallback = {
   "react-native-sqlite-storage": false,
 };
 
+// There's something a little off in source maps in some exceljs
+// dependencies - tell webpack we don't care.
+const sourceMapLoader = base.module.rules[1];
+if (sourceMapLoader.use[0] !== 'source-map-loader') {
+  throw new Error('cannot find source map loader');
+}
+sourceMapLoader.exclude = [
+  /node_modules\/fast-csv/,
+  /node_modules\/saxes/,
+  /node_modules\/xmlchars/,
+  /node_modules\/@fast-csv/
+];
+
 const webworker = {
   ...base,
   target: 'webworker',

--- a/ext/package.json
+++ b/ext/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "better-sqlite3": "8.1.0",
+    "core-js": "^3.32.1",
     "crypto-browserify": "^3.12.0",
     "pyodide": "0.23.4",
     "sql.js": "^1.8.0",

--- a/ext/yarn.lock
+++ b/ext/yarn.lock
@@ -166,6 +166,11 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+core-js@^3.32.1:
+  version "3.32.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.32.1.tgz#a7d8736a3ed9dd05940c3c4ff32c591bb735be77"
+  integrity sha512-lqufgNn9NLnESg5mQeYsxQP5w7wrViSj0jr/kv6ECQiByzQkrn1MKvV0L3acttpDqfQrHLwr2KCMgX5b8X+lyQ==
+
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"

--- a/page/index_custom.html
+++ b/page/index_custom.html
@@ -17,6 +17,10 @@
   </p>
 
   <p>
+    Same, but without name <a data-grist-csv-open href="./StudentData.csv">CSV</a>.
+  </p>
+
+  <p>
     Or any <a data-grist-doc-open="./investment-research.grist" href="#" data-name="Students" data-single-page>Grist document</a> as well.
   </p>
 


### PR DESCRIPTION
This uses some new hooks being added in https://github.com/gristlabs/grist-core/pull/665 to enable csv, xlsx, and .grist downloads.

An alternative approach to reroute requests to front-end code would have been a service worker. For downloads, a tiny little hook in grist-core was sufficient, so I went with that for simplicity. It may be that we'll need a service worker later, at which point the plumbing could be changed a little.