### PR TITLE
For file-opens, such as imports, use Puter's open dialog rather than the browser's native one.

### DIFF
--- a/ext/app/client/HookStub.ts
+++ b/ext/app/client/HookStub.ts
@@ -3,10 +3,14 @@ import { IGristUrlState } from 'app/common/gristUrls';
 import { getGristConfig } from 'app/common/urlUtils';
 import { gristOverrides } from 'app/pipe/GristOverrides';
 import { setupNewHooks } from 'app/client/NewHooks';
+import type { FileDialogOptions } from 'app/client/ui/FileDialog';
 import { IAttrObj } from 'grainjs';
 
 export interface IHooksExtended extends IHooks {
   save?: () => void;
+
+  // If set, used to implement FileDialog's open(), used in for importing files.
+  open?: (options: FileDialogOptions) => Promise<FileList>;
 
   // If set, this is called in place of XMLHttpRequest's send() method when the body argument is
   // FormData. Note that this will also affect fetch() requests with such body. The original send
@@ -31,6 +35,7 @@ export const hooks: IHooksExtended = {
   },
   maybeModifyLinkAttrs,
   save: gristOverrides.behaviorOverrides?.save,
+  open: gristOverrides.behaviorOverrides?.open,
   upload: (...args) => (window as any).uploadHook?.(...args),
 };
 

--- a/ext/app/pipe/GristOverrides.ts
+++ b/ext/app/pipe/GristOverrides.ts
@@ -3,6 +3,7 @@
  * Here we at least try to shepherd the state into a single place.
  */
 
+import type { FileDialogOptions } from 'app/client/ui/FileDialog';
 
 export interface GristOverrides {
   bootstrapGristPrefix?: string;
@@ -39,6 +40,7 @@ export interface GristOverrides {
     onOpenComplete?: () => void;
     onChange?: () => void;
     save?: () => void;
+    open?: (options: FileDialogOptions) => Promise<FileList>;
     rename?: (newName: string) => Promise<unknown>;
   };
 }

--- a/ext/app/pipe/tsconfig.json
+++ b/ext/app/pipe/tsconfig.json
@@ -3,4 +3,9 @@
   "include": [
     "./GristOverrides.ts",
   ],
+  "references": [
+    { "path": "../../../app/client" },
+    { "path": "../../../app/common" },
+    { "path": "../../../app/plugin" },
+  ]
 }

--- a/page/puter.js
+++ b/page/puter.js
@@ -100,6 +100,19 @@ async function save() {
   }
 }
 
+async function open(options) {
+  const accept = options.accept ? options.accept.split(",") : supportedExtensions;
+  options = {...options, accept};
+  const itemOrItems = await puter.ui.showOpenFilePicker(options);
+  const items = itemOrItems.length ? itemOrItems : [itemOrItems];
+  // Trick to construct a FileList (from https://stackoverflow.com/a/56447852/328565)
+  const list = new DataTransfer();
+  for (const item of items) {
+    list.items.add(new File([await item.read()], item.name));
+  }
+  return list.files;
+}
+
 // Implement renaming via puter.
 async function rename(newName) {
   // Note: _puterFSItem.rename() method exists too but fails (and isn't well-documented).
@@ -121,6 +134,7 @@ const behaviorOverrides = {
   onOpenComplete() { _isOpen = true; },
   onChange() { if (_isOpen) { markAsSaved(false); } },
   save,
+  open,
   rename,
 };
 


### PR DESCRIPTION
Also fix extensions (which Grist incorrectly fails to specify) to use the same list that we use to decide which files to allow opening with Grist.